### PR TITLE
ci: gate releases behind CI + document rewrite features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,16 @@ on:
   push:
     branches: [main, master]
   pull_request:
+  # Allow this workflow to be called by the release pipeline (main.yml)
+  # so a release can only be cut when typecheck + tests + build pass.
+  workflow_call:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Skip pushes whose commit message contains [skip ci] (e.g. the release
+    # pipeline's version-sync commit). PRs and workflow_call always run.
+    if: "github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,33 +1,33 @@
-name: Build and Release
+name: Release
 
+# Release pipeline: runs only on version tags. Day-to-day validation
+# (typecheck + tests + build on every push/PR) lives in ci.yml.
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*'
-    paths-ignore:
-      - '**.md'
-  pull_request:
-    branches: [ main ]
 
 permissions:
   contents: write
 
 jobs:
+  # Gate: reuse the full CI workflow. The release jobs below depend on this,
+  # so an untested commit can never produce a release.
+  ci:
+    uses: ./.github/workflows/ci.yml
+
   build:
-    # Skip if the commit message contains [skip ci]
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    needs: ci
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         token: ${{ secrets.PAT_TOKEN || github.token }}
-    
+
     - name: Use Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '20'
         cache: 'npm'
@@ -37,16 +37,15 @@ jobs:
 
     - name: Set version from tag
       id: get_version
-      if: startsWith(github.ref, 'refs/tags/v')
       run: |
         VERSION=${GITHUB_REF#refs/tags/v}
         echo "version=$VERSION" >> $GITHUB_OUTPUT
-        
+
         # Use our sync-version script instead of manual updates
         npm version $VERSION --no-git-tag-version --allow-same-version
         set -e
         node scripts/sync-version.js || { echo "Error: sync-version.js failed"; exit 1; }
-        
+
         # Commit version updates with [skip ci] to avoid circular trigger
         git config --global user.name 'GitHub Actions'
         git config --global user.email 'actions@github.com'
@@ -63,13 +62,11 @@ jobs:
       run: mkdir -p artifacts
 
     - name: Create versioned zip
-      if: startsWith(github.ref, 'refs/tags/v')
       run: |
         cd dist
         zip -r "../artifacts/azure-devops-wiki-editor-v${{ steps.get_version.outputs.version }}.zip" *
 
     - name: Upload build artifacts
-      if: startsWith(github.ref, 'refs/tags/v')
       uses: actions/upload-artifact@v4
       with:
         name: extension-dist-v${{ steps.get_version.outputs.version }}
@@ -79,7 +76,6 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
 
     steps:
     - name: Get Version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Live demo:** the WYSIWYG editor now runs in the browser at <https://bthos.github.io/azure-devops-wiki-editor/> — `playground.html` is built and deployed to GitHub Pages on every push to `main` (`.github/workflows/pages.yml`).
+- **WYSIWYG ⇄ Markdown toggle switch:** flip between the WYSIWYG editor and the native Azure DevOps Markdown editor in place, without leaving the page (`createModeToggle` / `enableWysiwygMode` / `disableWysiwygMode` in `src/main.ts`). Toggle-switch position (left/right) is configurable from the popup.
+- **Popup settings:** toggle-switch **position** (left/right) and **Custom Domains** management for on-premises Azure DevOps Server, plus dark-mode-aware popup styling that follows the browser's `prefers-color-scheme` (`public/popup.html`, `public/popup.js`).
+- **Azure DevOps theme integration:** the editor follows the active ADO theme (Light, Dark, High Contrast Dark/Light) via `isDarkTheme()` and `WIKI_EDITOR_DARK_CLASS` applied at mount.
+- **Table toolbar:** grid picker to insert tables by dimension, plus add/delete row & column and delete-table commands, and HTML-block insertion (`wiki-table-commands.ts`, `wiki-pm-toolbar-html.ts`).
 - **Work item refs (`#12345`):** markdown-it recognizes Azure DevOps-style references (≥2 digits, not URL fragments / hex-style tails). ProseMirror mark `wikiWorkItem` renders as chip (`.ado-work-item-ref`); saved markdown stays plain `#12345`. Link to `_workitems/edit/{id}` when the page URL is an ADO wiki (`buildAdoWorkItemEditHref` in `ado-wiki-api.ts`). Tests: `wiki-work-item-markdown.spec.ts`, `wiki-work-item-match.ts`.
 - **Video embeds (ADO `::: video` … `:::`):** HTTPS-only URLs, max length 2048, no credentials in the URL. ProseMirror atom `ado_video_block` with widget (`wiki-video-widget-plugin.ts`); direct `https` links to `.mp4` / `.webm` / `.ogg` get a native `<video controls>` preview when the host allows it (otherwise placeholder + **Open** link). Parse/serialize round-trip via `wiki-markdown-video-container-it.ts`, `wiki-markdown-parser.ts`, `wiki-markdown-serializer.ts`; toolbar inserts a sample HTTPS MP4 (`insertWikiVideoBlock`). Tests: `wiki-video-url.spec.ts`, `wiki-video-markdown.spec.ts`.
 - **Toolbar:** buttons **Mermaid**, **f(x)** (inline math), and **∫** (display math) next to Code block; wired in `wiki-pm-toolbar-html.ts` / `wiki-toolbar.ts` with `insertWikiMermaidBlock`, `insertWikiMathInline`, `insertWikiMathDisplayBlock` in `wiki-insert-markers.ts`.
@@ -17,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Wiki math (KaTeX):** safe delimiters `\(...\)`, `$$…$$`, and `\[…\]` (no single-`$` inline). `markdown-it` rules, `wiki_math_*` schema atoms, serializer normalizes display to `$$` blocks, node views + `trust: false` rendering. KaTeX CSS/fonts copied to `dist/katex/` at build; manifest loads `katex/katex.min.css`. Tests: `tests/unit/wiki-math-markdown.spec.ts`.
 - **Readonly code-block syntax highlighting** in the wiki code widget (`wiki-code-highlight.ts`, highlight.js with ten bundled grammars + aliases). Unknown languages and very large snippets fall back to plain text; dark theme token colors in `ado-theme.css`. Tests: `tests/unit/wiki-code-highlight.spec.ts`.
 - **Editor history (Option C):** `wiki-editor-history-config.ts` tunes `prosemirror-history` (`depth`, `newGroupDelay`). Multi-file attachment uploads dispatch as **one** undo step via `closeHistory` + batched steps in `wiki-attachment-upload.ts`. Tests: `tests/unit/wiki-editor-history.spec.ts`.
+
+### Changed
+
+- **Major editor rewrite (#20):** the extension now ships a hand-rolled **ProseMirror + markdown-it** WYSIWYG editor bundled with **esbuild**. The previous editor and its `webpack` build were removed; tests moved to **Vitest**. This is the foundation for the toggle, table, math, Mermaid, video, work-item, and theming features above.
+
+> **Note:** `package.json` / `public/manifest.json` are at **3.1.3**, but no `v3.1.x` tags or per-version changelog entries were cut for the rewrite line. The changes above are grouped under `[Unreleased]` until a release is tagged. When cutting it, decide whether the published Chrome Web Store version (currently 1.0.10) adopts the `3.x` manifest version or restarts numbering.
 
 ## [3.1.0] - 2026-04-21
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 Chrome extension that replaces the default Azure DevOps wiki markdown editor with a **WYSIWYG** experience powered by **ProseMirror**, **markdown-it** (GFM-style tables and task lists), and **remark**-family utilities where needed for Azure DevOps–specific markdown.
 
+## 🔗 Live Demo
+
+Try the WYSIWYG editor right in your browser — no install required:
+
+**👉 [bthos.github.io/azure-devops-wiki-editor](https://bthos.github.io/azure-devops-wiki-editor/)**
+
+The demo is the project's `playground.html` deployed to GitHub Pages (`.github/workflows/pages.yml`); it runs the same editor bundle the extension ships.
+
 ## 🚀 Prerequisites
 
 - [Node.js](https://nodejs.org/) (v12 or higher)
@@ -101,30 +109,26 @@ If the editor doesn't appear:
 
 ## ✨ Features
 
-- WYSIWYG editing interface for Azure DevOps Wiki pages
-- Activates automatically on in-app navigation — no page reload required when arriving at a wiki page from another Azure DevOps page (SPA navigation support since v3.1.1)
-- Real-time preview of markdown changes
-- Support for all standard markdown syntax:
-  - Headers (H1-H6)
-  - Lists (ordered and unordered)
-  - Tables with easy editing interface
-  - Code blocks with syntax highlighting
-  - Task lists (checkboxes)
-  - Blockquotes
-- Azure DevOps specific features:
-  - @mentions support
+- **WYSIWYG editing** for Azure DevOps Wiki pages — edit rich content without hand-writing Markdown.
+- **One-click WYSIWYG ⇄ Markdown toggle** — flip back to the native Azure DevOps Markdown editor anytime for advanced formatting. Toggle-switch position (left/right) is configurable in the extension popup.
+- **Activates on in-app (SPA) navigation** — no page reload required when arriving at a wiki page from another Azure DevOps page (since v3.1.1).
+- **Standard Markdown:** headers (H1–H6), ordered/unordered lists, task lists (checkboxes), blockquotes, and code blocks.
+- **Tables** — insert via a visual **grid picker**, then add/remove rows & columns or delete the table from the toolbar dropdown.
+- **Text & highlight colors** — native color pickers; serialized as inline `<span style="color:…;background-color:…">` wiki HTML (`wikiStyle` mark).
+- **Code syntax highlighting** in read-only code blocks (highlight.js).
+- **Math (KaTeX)** — inline `$x+y$` and display `$$…$$` / `\[…\]`; toolbar buttons for inline & display math.
+- **Mermaid diagrams** — Azure DevOps `::: mermaid … :::` blocks rendered live; fenced ` ```mermaid ` is normalized to the ADO container on save.
+- **Video embeds** — Azure DevOps `::: video … :::` blocks with native `<video>` preview for direct MP4/WebM/Ogg links.
+- **Azure DevOps–specific markup:**
+  - @mentions (with people picker)
+  - Work item references (`#123`) rendered as clickable chips linking to the work item
   - Wiki TOC generation (`[[_TOC_]]`)
   - Wiki links
-  - Work item links (#123)
-- **ProseMirror toolbar:** text and highlight colors (native color pickers, `wikiStyle` mark → raw `<span style="color:…;background-color:…">` in saved markdown)
-- Image upload and embedding
-- Split screen mode (editor/preview)
-- Full screen editing mode
-
-## 📚 Developer documentation
-
-- **[Wiki attachments (Azure DevOps REST)](docs/wiki-attachments.md)** — REST contract, Base64 body behavior, and debugging notes for upload (`attachment-service.ts`).  
-- **[Wiki WYSIWYG editor (ProseMirror)](docs/wiki-editor.md)** — DOM contract (`wiki-editor-root`, …), `wikiStyle` mark, toolbar color UI, related source paths.
+- **Image & file upload** — drag, drop, or paste; multi-file uploads collapse into a single undo step.
+- **Undo/redo history** tuned for the wiki editing flow.
+- **Theme aware** — automatically follows your Azure DevOps theme (Light, Dark, High Contrast Dark/Light); the popup follows your browser's dark-mode preference.
+- **Custom domains** — works with Azure DevOps cloud (`dev.azure.com`, `*.visualstudio.com`) and on-premises Azure DevOps Server via custom domains added in the popup.
+- Split-screen (editor/preview) and full-screen editing modes.
 
 ## ⌨️ Keyboard Shortcuts
 


### PR DESCRIPTION
## Summary

Restructures the CI/release pipeline so a release can only be cut from a green build, and updates `CHANGELOG.md` / `README.md` to document the features that landed with the ProseMirror rewrite (#20).

Branch pushed as `ci-release-sync` (the pre-existing `origin/ci-updates` is a stale April-2025 / webpack-era line that diverged from this branch's common ancestor; it was left untouched rather than force-pushed).

## CI / release changes (`db8048f`)

- **`ci.yml`** — now exposes `workflow_call` so the release pipeline can reuse it as a gate; build job skips pushes whose commit message contains `[skip ci]` (e.g. the release version-sync commit), while PRs and `workflow_call` always run.
- **`main.yml`** — renamed *Build and Release* → *Release*; triggers **only on `v*` tags** (day-to-day validation now lives entirely in `ci.yml`). Adds a `ci` job (`uses: ./.github/workflows/ci.yml`) that the `build` job `needs:`, so an untested commit can never produce a release. Bumps `actions/checkout` and `actions/setup-node` v3 → v4.

## Docs (`890db03`)

- **`CHANGELOG.md`** — documents under `[Unreleased]`: live GitHub Pages demo, WYSIWYG ⇄ Markdown toggle, popup settings (toggle position + custom domains), ADO theme integration, and the table toolbar; adds a **Changed** entry for the #20 ProseMirror + esbuild rewrite. Includes a note flagging that `package.json` / `manifest.json` are at **3.1.3** with no `v3.1.x` tags cut yet — a versioning decision to make before the next release.
- **`README.md`** — adds a **Live Demo** section (GitHub Pages) and rewrites the Features list to cover the toggle, grid-picker tables, text/highlight colors, code highlighting, KaTeX math, Mermaid, video embeds, and work-item chips.

## Diffstat

```
.github/workflows/ci.yml   |  6 ++++++
.github/workflows/main.yml | 32 +++++++++++++-----------------
CHANGELOG.md               | 11 +++++++++++
README.md                  | 48 ++++++++++++++++++++++---------------------
```

## Test plan

- [ ] Confirm `ci.yml` runs on this PR (typecheck + tests + build).
- [ ] Confirm `main.yml` no longer triggers on branch pushes/PRs (tag-only).
- [ ] Eyeball CHANGELOG / README rendering on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
