### PR TITLE
fix(ci): tolerate already-synced version in release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,12 +46,19 @@ jobs:
         set -e
         node scripts/sync-version.js || { echo "Error: sync-version.js failed"; exit 1; }
 
-        # Commit version updates with [skip ci] to avoid circular trigger
+        # Commit version updates with [skip ci] to avoid circular trigger.
+        # When the tag already matches the committed version the sync produces
+        # no changes — that is success, not failure, so only commit/push when
+        # something actually changed.
         git config --global user.name 'GitHub Actions'
         git config --global user.email 'actions@github.com'
         git add package.json public/manifest.json
-        git commit -m "chore: Sync versions to $VERSION [skip ci]"
-        git push origin HEAD:main
+        if git diff --staged --quiet; then
+          echo "Versions already in sync with tag; nothing to commit."
+        else
+          git commit -m "chore: Sync versions to $VERSION [skip ci]"
+          git push origin HEAD:main
+        fi
 
     - name: Build
       run: npm run build


### PR DESCRIPTION
## Problem

The `v3.1.3` release run failed in the **build → "Set version from tag"** step:

```
HEAD detached at v3.1.3
nothing to commit, working tree clean
Error: Process completed with exit code 1.
```

The step syncs versions and then runs `git commit` **unconditionally**. When the
tag already matches the version committed on `main` (the normal case — `main` was
already at `3.1.3`), the sync produces no diff, so `git commit` exits `1` and the
`bash -e` step fails. The build, zip, and GitHub Release jobs never run.

## Fix

Guard the commit/push so an already-in-sync tree is treated as success:

```bash
git add package.json public/manifest.json
if git diff --staged --quiet; then
  echo "Versions already in sync with tag; nothing to commit."
else
  git commit -m "chore: Sync versions to $VERSION [skip ci]"
  git push origin HEAD:main
fi
```

## After merge

Move the `v3.1.3` tag onto the merged commit and re-push it to re-trigger the
release with the corrected workflow (no GitHub Release exists yet, so this is safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
